### PR TITLE
[BUGFIX] 유저 생성 동시성 문제 버그 수정 

### DIFF
--- a/src/main/java/com/randps/randomdefence/domain/user/service/UserService.java
+++ b/src/main/java/com/randps/randomdefence/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.randps.randomdefence.domain.user.service.port.UserRandomStreakReposit
 import com.randps.randomdefence.domain.user.service.port.UserRepository;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import javax.persistence.EntityExistsException;
 import javax.transaction.Transactional;
 import lombok.Builder;
@@ -43,9 +44,9 @@ public class UserService {
      */
     @Transactional
     public User save(UserSave userSave) throws JsonProcessingException {
-        User existUser = userRepository.findByBojHandle(userSave.getBojHandle()).orElse(null);
+        Optional<User> existUser = userRepository.findByBojHandle(userSave.getBojHandle());
         synchronized (this) {
-            if (existUser != null || userSaveProcessSet.get(userSave.getBojHandle()) != null) {
+            if (existUser.isPresent() || userSaveProcessSet.get(userSave.getBojHandle()) != null) {
                 throw new EntityExistsException("이미 존재하는 유저는 생성할 수 없습니다.");
             } else {
                 // Process HashMap에 추가

--- a/src/main/java/com/randps/randomdefence/domain/user/service/UserService.java
+++ b/src/main/java/com/randps/randomdefence/domain/user/service/UserService.java
@@ -43,8 +43,9 @@ public class UserService {
      */
     @Transactional
     public User save(UserSave userSave) throws JsonProcessingException {
+        User existUser = userRepository.findByBojHandle(userSave.getBojHandle()).orElse(null);
         synchronized (this) {
-            if (userSaveProcessSet.get(userSave.getBojHandle()) != null) {
+            if (existUser != null || userSaveProcessSet.get(userSave.getBojHandle()) != null) {
                 throw new EntityExistsException("이미 존재하는 유저는 생성할 수 없습니다.");
             } else {
                 // Process HashMap에 추가

--- a/src/main/java/com/randps/randomdefence/domain/user/service/UserService.java
+++ b/src/main/java/com/randps/randomdefence/domain/user/service/UserService.java
@@ -8,8 +8,8 @@ import com.randps.randomdefence.domain.user.dto.UserMentionDto;
 import com.randps.randomdefence.domain.user.dto.UserSave;
 import com.randps.randomdefence.domain.user.service.port.UserRandomStreakRepository;
 import com.randps.randomdefence.domain.user.service.port.UserRepository;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import javax.persistence.EntityExistsException;
 import javax.transaction.Transactional;
 import lombok.Builder;
@@ -36,14 +36,20 @@ public class UserService {
 
     private final UserSolvedProblemService userSolvedProblemService;
 
+    private static HashMap<String, Boolean> userSaveProcessSet = new HashMap<>();
+
     /*
      * 유저를 DB에 저장한다.
      */
     @Transactional
     public User save(UserSave userSave) throws JsonProcessingException {
-        Optional<User> isExistUser = userRepository.findByBojHandle(userSave.getBojHandle());
-        if (isExistUser.isPresent()) {
-            throw new EntityExistsException("이미 존재하는 유저는 생성할 수 없습니다.");
+        synchronized (this) {
+            if (userSaveProcessSet.get(userSave.getBojHandle()) != null) {
+                throw new EntityExistsException("이미 존재하는 유저는 생성할 수 없습니다.");
+            } else {
+                // Process HashMap에 추가
+                userSaveProcessSet.put(userSave.getBojHandle(), true);
+            }
         }
         if (!(userSave.getManager() == 0 || userSave.getManager() == 1)) {
             throw new IllegalArgumentException("잘못된 파라미터가 전달되었습니다.");
@@ -85,6 +91,8 @@ public class UserService {
         // 전날의 랜덤 스트릭 잔디 생성 (새로운 유저 생성 시 에러 방지용)
         userGrassService.makeYesterdayGrass(userRandomStreak);
 
+        // Process HashMap에서 삭제
+        userSaveProcessSet.remove(userSave.getBojHandle());
         return user;
     }
 

--- a/src/test/java/com/randps/randomdefence/domain/mock/TestContainer.java
+++ b/src/test/java/com/randps/randomdefence/domain/mock/TestContainer.java
@@ -320,5 +320,4 @@ public class TestContainer {
                 .build();
     }
 
-
 }

--- a/src/test/java/com/randps/randomdefence/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/randps/randomdefence/domain/user/service/UserServiceTest.java
@@ -150,18 +150,18 @@ public class UserServiceTest {
                 .manager(1L)
                 .emoji("🛠️")
                 .build();
-        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ExecutorService pool = Executors.newFixedThreadPool(2);
 
         // when & then
         assertThatThrownBy(() -> {
-            Future<?> future1 = executor.submit(()->{
+            Future<?> future1 = pool.submit(()->{
                 try {
                     testContainer.userService.save(userSave);
                 } catch (JsonProcessingException e) {
                     throw new RuntimeException(e);
                 }
             });
-            Future<?> future2 = executor.submit(()->{
+            Future<?> future2 = pool.submit(()->{
                 try {
                     testContainer.userService.save(userSave);
                 } catch (JsonProcessingException e) {
@@ -172,9 +172,10 @@ public class UserServiceTest {
                 future1.get();
                 future2.get();
             } catch (ExecutionException ee) {
+                pool.shutdownNow();
                 throw ee.getCause();
             }
-            executor.shutdown();
+            pool.shutdown();
         }).isInstanceOf(EntityExistsException.class);
     }
 

--- a/src/test/java/com/randps/randomdefence/global/component/mock/FakeSolvedacDelayedParserImpl.java
+++ b/src/test/java/com/randps/randomdefence/global/component/mock/FakeSolvedacDelayedParserImpl.java
@@ -1,0 +1,46 @@
+package com.randps.randomdefence.global.component.mock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.randps.randomdefence.global.component.parser.SolvedacParser;
+import com.randps.randomdefence.global.component.parser.dto.UserScrapingInfoDto;
+import java.util.List;
+
+public class FakeSolvedacDelayedParserImpl  implements SolvedacParser {
+
+    private UserScrapingInfoDto userScrapingInfoDto;
+
+    public FakeSolvedacDelayedParserImpl(UserScrapingInfoDto userScrapingInfoDto) {
+        this.userScrapingInfoDto = userScrapingInfoDto;
+    }
+
+    @Override
+    public List<Object> getSolvedProblemList(String userName) throws JsonProcessingException {
+        return null;
+    }
+
+    @Override
+    public JsonNode crawlingUserInfo(String bojHandle) throws JsonProcessingException {
+        return null;
+    }
+
+    @Override
+    public Boolean isTodaySolved(JsonNode userInfo) {
+        return null;
+    }
+
+    @Override
+    public Integer countTodaySolved(JsonNode userInfo) {
+        return null;
+    }
+
+    @Override
+    public UserScrapingInfoDto getSolvedUserInfo(String bojHandle) throws JsonProcessingException {
+        try {
+            Thread.sleep(1000 * 10);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("error occurred while waiting for 10 seconds.");
+        }
+        return userScrapingInfoDto;
+    }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
같은 유저를 생성하는 요청이 여러개가 동시에 요청된다면 Transaction으로 반영되는 유저의 정보가 DB에 아직 반영되지 않았기 때문에 유저 정보 중복 테스트를 통과하는 버그가 존재합니다.

Issue Number: N/A


## What is the new behavior?
유저를 생성하는 Service Bean인 UserService 객체에 static으로 HashMap을 만들어서 현재 생성중인 유저의 정보를 thread-safe하게 관리해서 쓰레드 동기화에 드는 오버헤드를 줄이고 버그를 수정했습니다.

이에 따른 테스트코드또한 작성했습니다.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
